### PR TITLE
Remove unused tokio-{stream,util} deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 semver = "1.0.4"
 tokio = { features = ["full"], version = "1" }
-tokio-stream = "0.1.5"
-tokio-util = { features = ["io"], version = "0.6" }
 tracing = "0.1"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
These were cargo culted from the ostree-ext code and are unused
there too.