### PR TITLE
Fixes for child process monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/cgwalters/containers-image-proxy"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Take `&mut self` consistently

In order to implement proper error handling, we are going
to need to also access the singleton child process state.

(In the future we should support concurrent blob fetches
 which would return the `std::fs::File` which can be accessed
 concurrently/separately from the proxy.  But our users aren't
 doing concurrent fetches yet)

---

Check for child exit during all requests

I am seeing the proxy seeming to exit during a request.  We
need to also monitor the child process while making a request.

---

Use main request method for semver checking

Previously I refactored the code to have `impl_request_raw`
to check the semver so we could do the child process checking
at the same time.  But now that that's a default part of the main
request flow, clean things up here make the semver call not special.

---

Bump to 0.2.0 for API changes

---

