### PR TITLE
Use `capctl` for `PR_SET_PDEATHSIG`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,12 @@ version = "0.3.1"
 
 [dependencies]
 anyhow = "1.0"
+capctl = "0.2.0"
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 lazy_static = "1.4.0"
 nix = "0.22.0"
+libc = "0.2"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 semver = "1.0.4"


### PR DESCRIPTION
Rather than forking `setpriv` from `util-linux`, which on RHEL8 is too
old to understand `--pdeathsig`.  Motivated by having this work
out of the box on RHEL8.