### PR TITLE
ci: add jobs for MSRV checks and linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,63 +1,95 @@
-# This is copied from https://github.com/rust-analyzer/rust-analyzer/blob/master/.github/workflows/ci.yaml
-# But I added rustfmt too.
 name: CI
+
+permissions:
+  actions: read
+
 on:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
+  # Pinned toolchain for linting
+  ACTION_LINTS_TOOLCHAIN: 1.56.0
+  # Minimum supported Rust version (MSRV)
+  ACTION_MSRV_TOOLCHAIN: 1.54.0
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   CI: 1
-  RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
 
 jobs:
   rust:
     name: Rust
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
-
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
-          components: rustfmt, rust-src
-
-      - name: rustfmt
-        run: cargo fmt --all -- --check
-
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
-
       - name: Compile
         run: cargo test --no-run
-
       - name: Test
         run: cargo test -- --nocapture --quiet
-
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v2
         with:
           repository: ostreedev/ostree-rs-ext
           path: ostree-rs-ext
           fetch-depth: 20
-
       - name: Test ostree-rs-ext
         run: ./ci/test-ostree-rs-ext.sh
+  build-minimum-toolchain:
+    name: "Build, minimum supported toolchain (MSRV)"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: cargo build
+        run: cargo build
+  linting:
+    name: "Lints, pinned toolchain"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
+          default: true
+          components: rustfmt, clippy
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l
+      - name: cargo clippy (warnings)
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
This adds two jobs in order to check minimum toolchain compatibility,
and for overall linting.