### PR TITLE
Add certificate_authority to expose --cert-dir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v2
         with:
-          repository: ostreedev/ostree-rs-ext
+          repository: mkenigs/ostree-rs-ext
+          ref: cert_dir
           path: ostree-rs-ext
           fetch-depth: 20
       - name: Test ostree-rs-ext


### PR DESCRIPTION
Will help allow ostree pull images from internal registries
Helps https://github.com/ostreedev/ostree-rs-ext/issues/121

Also change authfile type from String to PathBuf