### PR TITLE
ci: Reset back to main ostreedev branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v2
         with:
-          repository: mkenigs/ostree-rs-ext
-          ref: cert_dir
+          repository: ostreedev/ostree-rs-ext
           path: ostree-rs-ext
           fetch-depth: 20
       - name: Test ostree-rs-ext


### PR DESCRIPTION
Now that https://github.com/ostreedev/ostree-rs-ext/pull/180
landed.  This completes the "ratcheting" we needed to do to land both
PRs.