### PR TITLE
Use compile time rather than runtime detection for v0_2_3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,12 @@ jobs:
           override: true
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
-      - name: Compile
+      - name: Compile (no features)
         run: cargo test --no-run
+      - name: Compile (all features)
+        run: cargo test --no-run --all-features
       - name: Test
-        run: cargo test -- --nocapture --quiet
+        run: cargo test --all-features -- --nocapture --quiet
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ tracing = "0.1"
 
 [lib]
 path = "src/imageproxy.rs"
+
+[features]
+proxy_v0_2_3 = []


### PR DESCRIPTION
I thought my initial code to dynamically detect the proxy
version was cool - it maximizes flexibility.  I think it is a pattern
we will want in the future.

However, what I realized when doing some work related to this in
ostree-ext is that for this particular API, we need to make it a hard
dependency.

So we might as well do the much simpler thing and make it a compile
time feature.  Then all we need to do is change the runtime code
to match on the build-time selected semver.