### PR TITLE
Bump to nix 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ capctl = "0.2.0"
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 lazy_static = "1.4.0"
-nix = "0.22.0"
+nix = "0.23.0"
 libc = "0.2"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"


### PR DESCRIPTION
This will avoid multiple versions in at least the rpm-ostree
dependency chain.