### PR TITLE
Hard require skopeo 1.6.0, use oci-spec in public API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,14 +50,15 @@ jobs:
         run: cargo test --no-run --all-features
       - name: Test
         run: cargo test --all-features -- --nocapture --quiet
-      - name: Checkout ostree-rs-ext
-        uses: actions/checkout@v2
-        with:
-          repository: ostreedev/ostree-rs-ext
-          path: ostree-rs-ext
-          fetch-depth: 20
-      - name: Test ostree-rs-ext
-        run: ./ci/test-ostree-rs-ext.sh
+      # TODO: Re-enable this when git master there lands https://github.com/ostreedev/ostree-rs-ext/pull/123
+      # - name: Checkout ostree-rs-ext
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: ostreedev/ostree-rs-ext
+      #     path: ostree-rs-ext
+      #     fetch-depth: 20
+      # - name: Test ostree-rs-ext
+      #   run: ./ci/test-ostree-rs-ext.sh
   build-minimum-toolchain:
     name: "Build, minimum supported toolchain (MSRV)"
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 anyhow = "1.0"
@@ -23,6 +23,3 @@ tracing = "0.1"
 
 [lib]
 path = "src/imageproxy.rs"
-
-[features]
-proxy_v0_2_3 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ capctl = "0.2.0"
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 nix = "0.23.0"
+oci-spec = "0.5.5"
 once_cell = "1.9.0"
 libc = "0.2"
 serde = { features = ["derive"], version = "1.0.125" }


### PR DESCRIPTION
Unfortunately we need to temporarily disable our revdep CI
for this.

Bump the semver.