### PR TITLE
Minimize `tokio` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 semver = "1.0.4"
-tokio = { features = ["full"], version = "1" }
+tokio = { features = ["fs", "io-util", "macros", "process", "rt", "sync"], version = "1" }
 tracing = "0.1"
 
 [lib]


### PR DESCRIPTION
I saw this go by
https://www.reddit.com/r/rust/comments/v8e9fa/local_async_executors_and_why_they_should_be_the/
and I think it's a good argument why not to use the multithreaded
tokio by default.