### PR TITLE
Add support for passing auth creds via fd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1.0.64"
 semver = "1.0.4"
 tokio = { features = ["fs", "io-util", "macros", "process", "rt", "sync"], version = "1" }
 tracing = "0.1"
+cap-tempfile = "1.0.1"
+cap-std-ext = "1.0"
 
 [lib]
 path = "src/imageproxy.rs"


### PR DESCRIPTION
Motivated by https://github.com/ostreedev/ostree-rs-ext/pull/413 which is in turn an adaption of code that lives in rpm-ostree today from https://github.com/coreos/rpm-ostree/commit/d661e8f974f8d2550a865c2866476160e333ec72 which aims to support privilege separation.

This doesn't lower privilege separation into this project (yet), just aids in passing data across boundaries.