### PR TITLE
Use rustix instead of capctl && release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ rust-version = "1.58.0"
 
 [dependencies]
 anyhow = "1.0"
-capctl = "0.2.0"
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 nix = "0.26"
 oci-spec = "0.5.5"
 once_cell = "1.9.0"
 libc = "0.2"
+rustix = { version = "0.37", features = ["process"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 semver = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.5.3"
+version = "0.5.4"
 rust-version = "1.58.0"
 
 [dependencies]

--- a/src/imageproxy.rs
+++ b/src/imageproxy.rs
@@ -186,8 +186,10 @@ impl TryFrom<ImageProxyConfig> for Command {
             let mut c = std::process::Command::new("skopeo");
             unsafe {
                 c.pre_exec(|| {
-                    capctl::prctl::set_pdeathsig(Some(libc::SIGTERM))
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                    rustix::process::set_parent_process_death_signal(Some(
+                        rustix::process::Signal::Term,
+                    ))
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
                 });
             }
             c


### PR DESCRIPTION
Use rustix instead of capctl

In the interest in having fewer random crates in the
dependency graph.

---

Release 0.5.4

---

