### PR TITLE
proxy: Fix build with new nix `recvmsg` lifetimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.58.1
+  ACTION_LINTS_TOOLCHAIN: 1.63.0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   CI: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
 version = "0.5.4"
-rust-version = "1.58.0"
+rust-version = "1.63.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/src/imageproxy.rs
+++ b/src/imageproxy.rs
@@ -118,7 +118,7 @@ fn new_seqpacket_pair() -> Result<(File, File)> {
 #[allow(unsafe_code)]
 fn file_from_scm_rights(cmsg: ControlMessageOwned) -> Option<File> {
     if let nixsocket::ControlMessageOwned::ScmRights(fds) = cmsg {
-        fds.get(0)
+        fds.first()
             .map(|&fd| unsafe { std::fs::File::from_raw_fd(fd) })
     } else {
         None
@@ -375,7 +375,7 @@ impl ImageProxy {
             r = childwait.as_mut() => {
                 let r = r??;
                 let stderr = String::from_utf8_lossy(&r.stderr);
-                return Err(anyhow::anyhow!("skopeo proxy unexpectedly exited during request method {}: {}\n{}", method, r.status, stderr))
+                Err(anyhow::anyhow!("skopeo proxy unexpectedly exited during request method {}: {}\n{}", method, r.status, stderr))
             }
         }
     }
@@ -467,7 +467,7 @@ impl ImageProxy {
         img: &OpenedImage,
     ) -> Result<oci_spec::image::ImageConfiguration> {
         let raw = self.fetch_config_raw(img).await?;
-        Ok(serde_json::from_slice(&raw).context("Deserializing config from skopeo")?)
+        serde_json::from_slice(&raw).context("Deserializing config from skopeo")
     }
 
     /// Fetch a blob identified by e.g. `sha256:<digest>`.

--- a/src/imageproxy.rs
+++ b/src/imageproxy.rs
@@ -314,9 +314,10 @@ impl ImageProxy {
             let mut buf = [0u8; MAX_MSG_SIZE];
             let mut cmsg_buffer = nix::cmsg_space!([RawFd; 1]);
             let iov = std::io::IoSliceMut::new(buf.as_mut());
+            let mut iov = [iov];
             let r = nixsocket::recvmsg::<()>(
                 sockfd.as_raw_fd(),
-                &mut [iov],
+                &mut iov,
                 Some(&mut cmsg_buffer),
                 nixsocket::MsgFlags::MSG_CMSG_CLOEXEC,
             )?;


### PR DESCRIPTION
proxy: Fix build with new nix `recvmsg` lifetimes

An updated nix fixes an incorrect lifetime.

cc https://github.com/nix-rust/nix/issues/2083

Signed-off-by: Colin Walters <walters@verbum.org>

---

build-sys: Bump MSRV to 1.63

Since rustix did.

Signed-off-by: Colin Walters <walters@verbum.org>

---

proxy: Fix a few stylistic clippy lints

Signed-off-by: Colin Walters <walters@verbum.org>

---

