### PR TITLE
Support cap-std-ext 3.0 too && CI updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,6 @@ on:
     branches: [ main ]
 
 env:
-  # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.63.0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   CI: 1
@@ -33,15 +31,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
-      - uses: dtolnay/rust-toolchain@stable
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l
       - name: Compile (no features)
         run: cargo test --no-run
       - name: Compile (all features)
         run: cargo test --no-run --all-features
       - name: Test
         run: cargo test --all-features -- --nocapture --quiet
+      - name: cargo clippy (non-gating)
+        run: cargo clippy
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v3
         with:
@@ -50,45 +51,3 @@ jobs:
           fetch-depth: 20
       - name: Test ostree-rs-ext
         run: ./ci/test-ostree-rs-ext.sh
-  build-minimum-toolchain:
-    name: "Build, minimum supported toolchain (MSRV)"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Detect crate MSRV
-        shell: bash
-        run: |
-          msrv=$(cargo metadata --format-version 1 --no-deps | \
-              jq -r '.packages | .[0].rust_version')
-          echo "Crate MSRV: $msrv"
-          echo "ACTION_MSRV_TOOLCHAIN=$msrv" >> $GITHUB_ENV
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: msrv
-      - name: cargo check
-        run: cargo check
-  linting:
-    name: "Lints, pinned toolchain"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          components: rustfmt, clippy
-      - name: cargo fmt (check)
-        run: cargo fmt -- --check -l
-      - name: cargo clippy (warnings)
-        run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,8 @@ serde_json = "1.0.64"
 semver = "1.0.4"
 tokio = { features = ["fs", "io-util", "macros", "process", "rt", "sync"], version = "1" }
 tracing = "0.1"
-cap-tempfile = "1.0.1"
-# We didn't use the rustix re-export, so we're compatible with 1.x and 2.x.
-cap-std-ext = ">= 1.0, < 3.0"
+# We support both versions
+cap-std-ext = ">= 2.0, <= 3.0"
 
 [lib]
 path = "src/imageproxy.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
 version = "0.5.5"
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/src/imageproxy.rs
+++ b/src/imageproxy.rs
@@ -5,8 +5,8 @@
 //! More information: <https://github.com/containers/skopeo/pull/1476>
 
 use anyhow::{anyhow, Context, Result};
-use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtCommandExt;
+use cap_std_ext::{cap_std, cap_tempfile};
 use futures_util::Future;
 use nix::sys::socket::{self as nixsocket, ControlMessageOwned};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
Support cap-std-ext 3.0 too

To make it easier to bump the deptree of everything to cap-std 2.0.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Bump rust-version = 1.70

Since C9S has long since had it.

---

ci: Drop MSRV checks, merge fmt and linting

This aligns with https://github.com/ostreedev/ostree-rs-ext/commit/7650946cfac1eaa829d643e3d1d80c1d19a1a1bd
Basically clippy has a low signal/reward ratio by default.

---

