### PR TITLE
lib: Support cap-std-ext 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = "1.0.64"
 semver = "1.0.4"
 tokio = { features = ["fs", "io-util", "macros", "process", "rt", "sync"], version = "1" }
 tracing = "0.1"
-# We support both versions
-cap-std-ext = ">= 2.0, <= 3.0"
+# We support versions 2, 3 and 4
+cap-std-ext = ">= 2.0, <= 4.0"
 
 [dev-dependencies]
 bytes = "1.5"


### PR DESCRIPTION
Because we're not affected by the cap-std API changes.