### PR TITLE
Update oci-spec, drop once-cell and libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,14 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.5.8"
+version = "0.5.9"
 rust-version = "1.70.0"
 
 [dependencies]
 anyhow = "1.0"
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
-oci-spec = "0.5.5"
-once_cell = "1.9.0"
-libc = "0.2"
+oci-spec = "0.6.5"
 rustix = { version = "0.38", features = ["process", "net"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"


### PR DESCRIPTION
Update to the latest semver for oci-spec.  While we're here, switch to using the std OnceCell and drop the unused libc dependency.