### PR TITLE
ci: revert ostree-rs-ext back to ostreedev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,11 +46,7 @@ jobs:
       - name: Checkout ostree-rs-ext
         uses: actions/checkout@v3
         with:
-          # repository: ostreedev/ostree-rs-ext
-          # Temporary fork until https://github.com/ostreedev/ostree-rs-ext/pull/663
-          # is published in a release
-          repository: jeckersb/ostree-rs-ext
-          ref: ocidir-0.3
+          repository: ostreedev/ostree-rs-ext
           path: ostree-rs-ext
           fetch-depth: 20
       - name: Test ostree-rs-ext


### PR DESCRIPTION
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
