### PR TITLE
proxy: Drop double-wrapping in `RequestInitiationError`

### DIFF
--- a/src/imageproxy.rs
+++ b/src/imageproxy.rs
@@ -446,12 +446,7 @@ impl ImageProxy {
         let req = Self::impl_request_raw(Arc::clone(&self.sockfd), Request::new(method, args));
         let mut childwait = self.childwait.lock().await;
         tokio::select! {
-            r = req => {
-                r.map_err(|e| Error::RequestInitiationFailure {
-                    method: method.to_string().into(),
-                    error: e.to_string().into()
-            })
-            }
+            r = req => { r }
             r = childwait.as_mut() => {
                 let r = r.map_err(|e| Error::Other(e.to_string().into()))??;
                 let stderr = String::from_utf8_lossy(&r.stderr);


### PR DESCRIPTION
See https://github.com/bootc-dev/bootc/issues/1284 - the error text is

`ERROR Upgrading: Creating importer: failed to invoke method OpenImage: failed to invoke method OpenImage: lstat ...`

This fixes the duplication of `failed to invoke method OpenImage`.

I think this was a regression from porting to use thiserror when I was changing the type of each individual function to return our Result type.