### PR TITLE
Release 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.9.2"
+version = "0.10.0"
 rust-version = "1.70.0"
 
 [dependencies]


### PR DESCRIPTION
We need to bump semver because we bumped oci-spec to 0.9.