### PR TITLE
Update version to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.10.0"
+version = "0.10.1"
 rust-version = "1.70.0"
 
 [dependencies]


### PR DESCRIPTION
This release includes
- Transport enum updates to be able to parse bare Transport without `:`